### PR TITLE
Formalize control and framework bundle projections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 FIRST_WAVE_SOURCE_REPO ?= ../confighub-scan
 
-.PHONY: test-python validate-copy-manifest validate-control-taxonomy validate-control-framework-bundle validate-framework-coverage-report validate-bundle-manifest validate-cross-tool-mapping validate-external-evidence-schema validate
+.PHONY: test-python validate-copy-manifest validate-control-taxonomy validate-control-framework-bundle validate-framework-coverage-report validate-bundle-manifest validate-cross-tool-mapping validate-external-evidence-schema validate-control-projections validate
 
 test-python:
 	python3 -m unittest \
 		test/test-build-bundle-manifest.py \
 		test/test-build-control-taxonomy-summary.py \
 		test/test-build-control-framework-bundle.py \
-		test/test-build-framework-coverage-report.py
+		test/test-build-framework-coverage-report.py \
+		test/test-validate-control-projections.py
 
 validate-copy-manifest:
 	python3 scripts/build-first-wave-copy-manifest.py --source-repo "$(FIRST_WAVE_SOURCE_REPO)" --check
@@ -30,6 +31,9 @@ validate-cross-tool-mapping:
 validate-external-evidence-schema:
 	python3 scripts/validate-external-evidence-schema.py
 
+validate-control-projections:
+	python3 scripts/validate-control-projections.py
+
 validate:
 	$(MAKE) test-python
 	$(MAKE) validate-copy-manifest FIRST_WAVE_SOURCE_REPO="$(FIRST_WAVE_SOURCE_REPO)"
@@ -39,3 +43,4 @@ validate:
 	$(MAKE) validate-bundle-manifest
 	$(MAKE) validate-cross-tool-mapping
 	$(MAKE) validate-external-evidence-schema
+	$(MAKE) validate-control-projections

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ As of 2026-04-02:
   pattern IDs
 - Kyverno, Trivy, and Kubescape mappings are published as bundle assets
 - the external evidence schema is published here
+- the control/framework projection contract is now explicit via
+  `dist/control-framework-bundle-v1.json`,
+  `dist/framework-coverage-report-v1.json`, and
+  `docs/BUNDLE-PROJECTIONS.md`
 - local validation is wired through `make validate`
 
 `confighub-scan` remains the engine and integration repo.
@@ -130,4 +134,5 @@ are in the right repo.
 - `../confighub-scan/docs/START-HERE.md`
 - `docs/MIGRATION-STATUS.md`
 - `docs/TAXONOMY.md`
+- `docs/BUNDLE-PROJECTIONS.md`
 - `dist/bundle-manifest-v1.json`

--- a/dist/README.md
+++ b/dist/README.md
@@ -7,3 +7,13 @@ This directory should eventually contain versioned outputs such as:
 - `risk-catalog-v1.json`
 - `risk-function-links-v1.json`
 - `cross-tool-mapping-v1.json`
+- `control-taxonomy-summary-v1.json`
+- `control-framework-bundle-v1.json`
+- `framework-coverage-report-v1.json`
+
+Projection guidance:
+- `control-taxonomy-summary-v1.json` is the authoring and CI summary view
+- `control-framework-bundle-v1.json` is the released projection for
+  control/framework consumers
+- `framework-coverage-report-v1.json` is the compact derived report for
+  coverage and discovery surfaces

--- a/docs/BUNDLE-PROJECTIONS.md
+++ b/docs/BUNDLE-PROJECTIONS.md
@@ -1,0 +1,91 @@
+# Bundle Projections
+
+This repo now publishes three different control/framework JSON views, and they
+do not all play the same role.
+
+## Source Of Truth
+
+The source of truth is still the YAML authoring layer:
+- `controls/**/*.yaml`
+- `frameworks/**/*.yaml`
+- `dist/risk-catalog-v1.json` for pattern metadata carried into the projections
+
+Those source files are promoted and grouped into the generated JSON artifacts
+below.
+
+## Projection Roles
+
+### 1. `dist/control-taxonomy-summary-v1.json`
+
+Use this as the **authoring and CI summary**.
+
+It is useful for:
+- coverage summaries
+- quick diffs during repo work
+- builders that need a compact inventory first
+
+It is **not** the main released consumer contract for control/framework users.
+
+### 2. `dist/control-framework-bundle-v1.json`
+
+Use this as the **canonical released projection** for consumers that want the
+promoted control and framework layer.
+
+It packages:
+- normalized control documents
+- normalized framework documents
+- pattern references pulled from the risk catalog
+
+This is the projection that answers:
+- what are the current promoted controls?
+- which frameworks group them?
+- which canonical pattern IDs do those controls cover?
+
+### 3. `dist/framework-coverage-report-v1.json`
+
+Use this as the **compact derived report** for discovery, coverage, and UI-like
+summary surfaces.
+
+It is intentionally smaller than the full control/framework bundle and focuses
+on:
+- framework-level pattern coverage
+- cross-family framework detection
+- summarized supported surfaces / consumers / detection modes
+
+## Release Rule
+
+For the current migration wave:
+- `control-framework-bundle-v1.json` is the released control/framework payload
+- `framework-coverage-report-v1.json` is the released compact report that sits
+  beside it
+- both are advertised in `dist/bundle-manifest-v1.json`
+- both are additive to the existing risk-catalog contract, not replacements for it
+
+## Compatibility Rule
+
+Existing `risk-catalog-v1.json` consumers can ignore these projections.
+
+That compatibility matters because:
+- `confighub-scan` still has consumers that only need catalog + mapping assets
+- the migration wave is intentionally additive and non-destructive
+- control/framework consumers should not force older risk-catalog readers to
+  change behavior
+
+## Validation Rule
+
+The released projection pair now has explicit schemas and validation:
+- `schema/control-framework-bundle-v1.schema.json`
+- `schema/framework-coverage-report-v1.schema.json`
+- `scripts/validate-control-projections.py`
+
+Run:
+
+```bash
+make validate
+```
+
+That validation checks:
+- both schemas are valid JSON Schema
+- both generated artifacts match their schemas
+- bundle counts and ID inventories match the underlying rows
+- framework report counts and cross-family IDs match the underlying bundle

--- a/docs/BUNDLE-SCOPE.md
+++ b/docs/BUNDLE-SCOPE.md
@@ -21,10 +21,20 @@ Optional alongside the same release set:
 - `control-framework-bundle-v1.json`
 - `framework-coverage-report-v1.json`
 
+Projection rule:
+- `control-taxonomy-summary-v1.json` is the authoring/CI summary
+- `control-framework-bundle-v1.json` is the canonical released projection for
+  control/framework consumers
+- `framework-coverage-report-v1.json` is the compact derived coverage report
+
+See also:
+- `docs/BUNDLE-PROJECTIONS.md`
+
 Current state:
 - the repo now generates `dist/bundle-manifest-v1.json`
 - the manifest now advertises the imported-evidence mapping files alongside the
   runtime catalog/link artifacts and the promoted-taxonomy artifacts
+- the control/framework projections now have explicit schemas and validation
 
 ## Cache Layout
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -9,3 +9,5 @@ During bootstrap, the active schema files still live under
 The first repo-native control and framework schemas now live here too:
 - `control-definition-v1.schema.json`
 - `framework-definition-v1.schema.json`
+- `control-framework-bundle-v1.schema.json`
+- `framework-coverage-report-v1.schema.json`

--- a/schema/control-framework-bundle-v1.schema.json
+++ b/schema/control-framework-bundle-v1.schema.json
@@ -1,0 +1,458 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confighub.ai/schema/control-framework-bundle-v1.schema.json",
+  "title": "Control Framework Bundle v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "repo_root",
+    "source_summary",
+    "source_catalog",
+    "control_count",
+    "framework_count",
+    "pattern_coverage_count",
+    "control_ids",
+    "framework_ids",
+    "pattern_ids",
+    "controls",
+    "frameworks"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "control-framework-bundle-v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_root": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_catalog": {
+      "type": "string",
+      "minLength": 1
+    },
+    "control_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "framework_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pattern_coverage_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "control_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^CTRL-[A-Z0-9-]+$"
+      },
+      "uniqueItems": true
+    },
+    "framework_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^FRM-[A-Z0-9-]+$"
+      },
+      "uniqueItems": true
+    },
+    "pattern_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^CCVE-[0-9]{4}-[0-9]{4}$"
+      },
+      "uniqueItems": true
+    },
+    "controls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/control"
+      }
+    },
+    "frameworks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/framework"
+      }
+    }
+  },
+  "$defs": {
+    "pattern_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "category",
+        "track",
+        "severity",
+        "confidence",
+        "tags"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^CCVE-[0-9]{4}-[0-9]{4}$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "raw"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "minLength": 1
+            },
+            "raw": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "example_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "path",
+        "purpose"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "remediation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "safety_class",
+        "guidance"
+      ],
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safety_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "guidance": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "evidence_expectations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intent_signals",
+        "live_signals",
+        "corroborating_sources"
+      ],
+      "properties": {
+        "intent_signals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "live_signals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "corroborating_sources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "slug",
+        "name",
+        "family",
+        "summary",
+        "description",
+        "maturity",
+        "severity",
+        "supported_surfaces",
+        "supported_consumers",
+        "detection_modes",
+        "resource_kinds",
+        "tags",
+        "example_refs",
+        "source_path",
+        "remediation",
+        "evidence_expectations",
+        "pattern_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^CTRL-[A-Z0-9-]+$"
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maturity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supported_surfaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "supported_consumers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detection_modes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resource_kinds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "example_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/example_ref"
+          }
+        },
+        "source_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "remediation": {
+          "$ref": "#/$defs/remediation"
+        },
+        "evidence_expectations": {
+          "$ref": "#/$defs/evidence_expectations"
+        },
+        "pattern_refs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pattern_ref"
+          }
+        }
+      }
+    },
+    "framework_control_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "slug",
+        "name",
+        "family",
+        "severity"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^CTRL-[A-Z0-9-]+$"
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "framework": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "slug",
+        "name",
+        "family",
+        "summary",
+        "description",
+        "maturity",
+        "platforms",
+        "tags",
+        "outcomes",
+        "source_path",
+        "control_ids",
+        "controls"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^FRM-[A-Z0-9-]+$"
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maturity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outcomes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "control_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^CTRL-[A-Z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "controls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/framework_control_ref"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/framework-coverage-report-v1.schema.json
+++ b/schema/framework-coverage-report-v1.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confighub.ai/schema/framework-coverage-report-v1.schema.json",
+  "title": "Framework Coverage Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_bundle",
+    "framework_count",
+    "cross_family_framework_ids",
+    "frameworks"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "framework-coverage-report-v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_bundle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "framework_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cross_family_framework_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^FRM-[A-Z0-9-]+$"
+      },
+      "uniqueItems": true
+    },
+    "frameworks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/framework_row"
+      }
+    }
+  },
+  "$defs": {
+    "severity_counts": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "framework_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "slug",
+        "name",
+        "family",
+        "maturity",
+        "platforms",
+        "tags",
+        "control_ids",
+        "control_count",
+        "control_families",
+        "pattern_ids",
+        "pattern_coverage_count",
+        "supported_surfaces",
+        "supported_consumers",
+        "detection_modes",
+        "severity_counts"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^FRM-[A-Z0-9-]+$"
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maturity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "control_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^CTRL-[A-Z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "control_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "control_families": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "pattern_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^CCVE-[0-9]{4}-[0-9]{4}$"
+          },
+          "uniqueItems": true
+        },
+        "pattern_coverage_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "supported_surfaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "supported_consumers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "detection_modes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "severity_counts": {
+          "$ref": "#/$defs/severity_counts"
+        }
+      }
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,3 +10,5 @@ Current repo-native scripts:
 - `build-first-wave-copy-manifest.py`
 - `build-control-taxonomy-summary.py`
 - `build-control-framework-bundle.py`
+- `build-framework-coverage-report.py`
+- `validate-control-projections.py`

--- a/scripts/validate-control-projections.py
+++ b/scripts/validate-control-projections.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Validate control/framework projection schemas and generated artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+    from jsonschema import Draft202012Validator
+except ImportError:
+    print("ERROR: jsonschema package required. Install with: pip install jsonschema")
+    sys.exit(1)
+
+
+CONTROL_BUNDLE_SCHEMA_PATH = Path("schema/control-framework-bundle-v1.schema.json")
+FRAMEWORK_REPORT_SCHEMA_PATH = Path("schema/framework-coverage-report-v1.schema.json")
+CONTROL_BUNDLE_PATH = Path("dist/control-framework-bundle-v1.json")
+FRAMEWORK_REPORT_PATH = Path("dist/framework-coverage-report-v1.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control-bundle-schema", type=Path, default=CONTROL_BUNDLE_SCHEMA_PATH)
+    parser.add_argument("--framework-report-schema", type=Path, default=FRAMEWORK_REPORT_SCHEMA_PATH)
+    parser.add_argument("--control-bundle", type=Path, default=CONTROL_BUNDLE_PATH)
+    parser.add_argument("--framework-report", type=Path, default=FRAMEWORK_REPORT_PATH)
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_schema_file(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    if not path.exists():
+        return None, [f"missing schema: {path}"]
+    schema = load_json(path)
+    errors: list[str] = []
+    try:
+        Draft202012Validator.check_schema(schema)
+    except jsonschema.SchemaError as exc:
+        errors.append(f"{path}: invalid JSON Schema: {exc.message}")
+    return schema, errors
+
+
+def validate_payload(name: str, schema: dict[str, Any], payload: dict[str, Any]) -> list[str]:
+    validator = Draft202012Validator(schema)
+    errors: list[str] = []
+    for error in validator.iter_errors(payload):
+        location = ".".join(str(part) for part in error.absolute_path)
+        if location:
+            errors.append(f"{name}: {location}: {error.message}")
+        else:
+            errors.append(f"{name}: {error.message}")
+    return errors
+
+
+def semantic_bundle_checks(bundle: dict[str, Any], name: str) -> list[str]:
+    errors: list[str] = []
+    controls = bundle.get("controls", [])
+    frameworks = bundle.get("frameworks", [])
+    control_ids = bundle.get("control_ids", [])
+    framework_ids = bundle.get("framework_ids", [])
+    pattern_ids = bundle.get("pattern_ids", [])
+
+    if bundle.get("control_count") != len(controls):
+        errors.append(f"{name}: control_count does not match controls length")
+    if bundle.get("framework_count") != len(frameworks):
+        errors.append(f"{name}: framework_count does not match frameworks length")
+    if sorted(control_ids) != sorted(control.get("id") for control in controls):
+        errors.append(f"{name}: control_ids does not match control objects")
+    if sorted(framework_ids) != sorted(framework.get("id") for framework in frameworks):
+        errors.append(f"{name}: framework_ids does not match framework objects")
+
+    derived_pattern_ids = sorted(
+        {
+            pattern_ref.get("id")
+            for control in controls
+            if isinstance(control, dict)
+            for pattern_ref in control.get("pattern_refs", [])
+            if isinstance(pattern_ref, dict) and isinstance(pattern_ref.get("id"), str)
+        }
+    )
+    if bundle.get("pattern_coverage_count") != len(derived_pattern_ids):
+        errors.append(f"{name}: pattern_coverage_count does not match unique pattern_refs")
+    if sorted(pattern_ids) != derived_pattern_ids:
+        errors.append(f"{name}: pattern_ids does not match unique pattern_refs")
+
+    indexed_controls = {
+        control.get("id"): control for control in controls if isinstance(control, dict) and isinstance(control.get("id"), str)
+    }
+    for framework in frameworks:
+        if not isinstance(framework, dict):
+            continue
+        ids = framework.get("control_ids", [])
+        refs = framework.get("controls", [])
+        framework_id = framework.get("id", "<unknown>")
+        if len(ids) != len(refs):
+            errors.append(f"{name}: framework {framework_id} control_ids/controls length mismatch")
+            continue
+        ref_ids = [ref.get("id") for ref in refs if isinstance(ref, dict)]
+        if ids != ref_ids:
+            errors.append(f"{name}: framework {framework_id} controls do not align with control_ids order")
+        missing = [control_id for control_id in ids if control_id not in indexed_controls]
+        if missing:
+            errors.append(f"{name}: framework {framework_id} references missing controls {missing}")
+    return errors
+
+
+def semantic_report_checks(report: dict[str, Any], name: str) -> list[str]:
+    errors: list[str] = []
+    frameworks = report.get("frameworks", [])
+    if report.get("framework_count") != len(frameworks):
+        errors.append(f"{name}: framework_count does not match frameworks length")
+
+    derived_cross_family = sorted(
+        framework.get("id")
+        for framework in frameworks
+        if isinstance(framework, dict)
+        and isinstance(framework.get("id"), str)
+        and len(framework.get("control_families", [])) > 1
+    )
+    if sorted(report.get("cross_family_framework_ids", [])) != derived_cross_family:
+        errors.append(f"{name}: cross_family_framework_ids does not match framework rows")
+
+    for framework in frameworks:
+        if not isinstance(framework, dict):
+            continue
+        framework_id = framework.get("id", "<unknown>")
+        control_ids = framework.get("control_ids", [])
+        pattern_ids = framework.get("pattern_ids", [])
+        if framework.get("control_count") != len(control_ids):
+            errors.append(f"{name}: framework {framework_id} control_count does not match control_ids length")
+        if framework.get("pattern_coverage_count") != len(pattern_ids):
+            errors.append(f"{name}: framework {framework_id} pattern_coverage_count does not match pattern_ids length")
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+
+    control_schema, errors = validate_schema_file(args.control_bundle_schema)
+    report_schema, report_errors = validate_schema_file(args.framework_report_schema)
+    errors.extend(report_errors)
+
+    if control_schema is None or report_schema is None:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    control_bundle = load_json(args.control_bundle)
+    framework_report = load_json(args.framework_report)
+
+    errors.extend(validate_payload(str(args.control_bundle), control_schema, control_bundle))
+    errors.extend(validate_payload(str(args.framework_report), report_schema, framework_report))
+    errors.extend(semantic_bundle_checks(control_bundle, str(args.control_bundle)))
+    errors.extend(semantic_report_checks(framework_report, str(args.framework_report)))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print("Control/framework projection validation passed")
+    print(f"  bundle schema: {args.control_bundle_schema}")
+    print(f"  report schema: {args.framework_report_schema}")
+    print(f"  bundle: {args.control_bundle}")
+    print(f"  report: {args.framework_report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test-validate-control-projections.py
+++ b/test/test-validate-control-projections.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Tests for control/framework projection validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "validate-control-projections.py"
+CONTROL_SCHEMA = REPO_ROOT / "schema" / "control-framework-bundle-v1.schema.json"
+REPORT_SCHEMA = REPO_ROOT / "schema" / "framework-coverage-report-v1.schema.json"
+
+
+class ValidateControlProjectionsTests(unittest.TestCase):
+    def write_json(self, path: Path, doc: dict[str, object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+    def test_valid_projection_pair_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundle = root / "bundle.json"
+            report = root / "report.json"
+            self.write_json(
+                bundle,
+                {
+                    "schema_version": "control-framework-bundle-v1",
+                    "generated_at": "2026-04-11T10:00:00Z",
+                    "repo_root": "/tmp/repo",
+                    "source_summary": "/tmp/repo/dist/control-taxonomy-summary-v1.json",
+                    "source_catalog": "/tmp/repo/dist/risk-catalog-v1.json",
+                    "control_count": 1,
+                    "framework_count": 1,
+                    "pattern_coverage_count": 1,
+                    "control_ids": ["CTRL-GITOPS-0001"],
+                    "framework_ids": ["FRM-GITOPS-0001"],
+                    "pattern_ids": ["CCVE-2025-0001"],
+                    "controls": [
+                        {
+                            "id": "CTRL-GITOPS-0001",
+                            "slug": "gitops-health",
+                            "name": "GitOps health",
+                            "family": "gitops-operators",
+                            "summary": "Detect GitOps health failures.",
+                            "description": "Detailed description.",
+                            "maturity": "seeded",
+                            "severity": "high",
+                            "supported_surfaces": ["live_state"],
+                            "supported_consumers": ["cli", "ai"],
+                            "detection_modes": ["native_rule"],
+                            "resource_kinds": ["Application"],
+                            "tags": ["gitops"],
+                            "example_refs": [],
+                            "source_path": "/tmp/repo/controls/gitops/gitops-health.yaml",
+                            "remediation": {
+                                "strategy": "diagnose_then_fix",
+                                "safety_class": "review_required",
+                                "guidance": ["Look at reconcile errors first."]
+                            },
+                            "evidence_expectations": {
+                                "intent_signals": ["spec.syncPolicy"],
+                                "live_signals": ["status.health.status"],
+                                "corroborating_sources": ["argocd app get"]
+                            },
+                            "pattern_refs": [
+                                {
+                                    "id": "CCVE-2025-0001",
+                                    "name": "Git source not ready",
+                                    "category": "STATE",
+                                    "track": "misconfiguration",
+                                    "confidence": "high",
+                                    "tags": ["gitops"],
+                                    "severity": {
+                                        "bucket": "high",
+                                        "raw": "high"
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "frameworks": [
+                        {
+                            "id": "FRM-GITOPS-0001",
+                            "slug": "gitops-operators",
+                            "name": "GitOps operators",
+                            "family": "gitops-operators",
+                            "summary": "Operator bundle.",
+                            "description": "Framework description.",
+                            "maturity": "seeded",
+                            "platforms": ["argocd"],
+                            "tags": ["gitops"],
+                            "outcomes": ["Make GitOps issues easier to triage."],
+                            "source_path": "/tmp/repo/frameworks/gitops-operators.yaml",
+                            "control_ids": ["CTRL-GITOPS-0001"],
+                            "controls": [
+                                {
+                                    "id": "CTRL-GITOPS-0001",
+                                    "slug": "gitops-health",
+                                    "name": "GitOps health",
+                                    "family": "gitops-operators",
+                                    "severity": "high"
+                                }
+                            ]
+                        }
+                    ]
+                },
+            )
+            self.write_json(
+                report,
+                {
+                    "schema_version": "framework-coverage-report-v1",
+                    "generated_at": "2026-04-11T10:00:00Z",
+                    "source_bundle": str(bundle),
+                    "framework_count": 1,
+                    "cross_family_framework_ids": [],
+                    "frameworks": [
+                        {
+                            "id": "FRM-GITOPS-0001",
+                            "slug": "gitops-operators",
+                            "name": "GitOps operators",
+                            "family": "gitops-operators",
+                            "maturity": "seeded",
+                            "platforms": ["argocd"],
+                            "tags": ["gitops"],
+                            "control_ids": ["CTRL-GITOPS-0001"],
+                            "control_count": 1,
+                            "control_families": ["gitops-operators"],
+                            "pattern_ids": ["CCVE-2025-0001"],
+                            "pattern_coverage_count": 1,
+                            "supported_surfaces": ["live_state"],
+                            "supported_consumers": ["ai", "cli"],
+                            "detection_modes": ["native_rule"],
+                            "severity_counts": {"high": 1}
+                        }
+                    ]
+                },
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--control-bundle-schema",
+                    str(CONTROL_SCHEMA),
+                    "--framework-report-schema",
+                    str(REPORT_SCHEMA),
+                    "--control-bundle",
+                    str(bundle),
+                    "--framework-report",
+                    str(report),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+            self.assertIn("Control/framework projection validation passed", result.stdout)
+
+    def test_semantic_mismatch_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundle = root / "bundle.json"
+            report = root / "report.json"
+            self.write_json(
+                bundle,
+                {
+                    "schema_version": "control-framework-bundle-v1",
+                    "generated_at": "2026-04-11T10:00:00Z",
+                    "repo_root": "/tmp/repo",
+                    "source_summary": "/tmp/repo/dist/control-taxonomy-summary-v1.json",
+                    "source_catalog": "/tmp/repo/dist/risk-catalog-v1.json",
+                    "control_count": 2,
+                    "framework_count": 0,
+                    "pattern_coverage_count": 0,
+                    "control_ids": ["CTRL-GITOPS-0001"],
+                    "framework_ids": [],
+                    "pattern_ids": [],
+                    "controls": [],
+                    "frameworks": []
+                },
+            )
+            self.write_json(
+                report,
+                {
+                    "schema_version": "framework-coverage-report-v1",
+                    "generated_at": "2026-04-11T10:00:00Z",
+                    "source_bundle": str(bundle),
+                    "framework_count": 0,
+                    "cross_family_framework_ids": [],
+                    "frameworks": []
+                },
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--control-bundle-schema",
+                    str(CONTROL_SCHEMA),
+                    "--framework-report-schema",
+                    str(REPORT_SCHEMA),
+                    "--control-bundle",
+                    str(bundle),
+                    "--framework-report",
+                    str(report),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("control_count does not match controls length", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit schemas for the released control/framework bundle and framework coverage report
- add a validator that checks both schemas and the generated projection artifacts
- document which control/framework JSON views are the released consumer projections vs the authoring summary

## Verification
- `python3 -m unittest test/test-validate-control-projections.py`
- `make validate`

Closes #3.