### PR TITLE
Refresh external Rego library review

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,5 @@ are in the right repo.
 - `../confighub-scan/docs/START-HERE.md`
 - `docs/MIGRATION-STATUS.md`
 - `docs/TAXONOMY.md`
+- `docs/EXTERNAL-REGO-LIBRARY-REVIEW.md`
 - `dist/bundle-manifest-v1.json`

--- a/dist/first-wave-copy-manifest-v1.json
+++ b/dist/first-wave-copy-manifest-v1.json
@@ -8,10 +8,10 @@
     "schema": 3
   },
   "copy_status_counts": {
-    "copied_drifted": 15,
-    "copied_matching": 24
+    "copied_drifted": 16,
+    "copied_matching": 23
   },
-  "generated_at": "2026-03-31T12:02:45+00:00",
+  "generated_at": "2026-04-11T10:46:51+00:00",
   "item_count": 39,
   "items": [
     {
@@ -165,12 +165,12 @@
     },
     {
       "category": "pattern_quality",
-      "copy_status": "copied_matching",
+      "copy_status": "copied_drifted",
       "destination": "quality/launch-rules-v1.json",
       "exists": true,
-      "size_bytes": 28834,
+      "size_bytes": 29226,
       "source": "risks/quality/launch-rules-v1.json",
-      "source_sha256": "c24ed856f80f507c9d2d5710d56d42e9b6db480e96d208a53b5ac4249d4efcb3",
+      "source_sha256": "21891803f1eb77bfd7fc4c36c8543b8f11cf27ee7e437b21342c47b146b70e66",
       "source_type": "file",
       "target": "quality/launch-rules-v1.json",
       "target_exists": true,
@@ -467,9 +467,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-inventory-v1.json",
       "exists": true,
-      "size_bytes": 4046324,
+      "size_bytes": 4046247,
       "source": "dist/quality/pattern-inventory-v1.json",
-      "source_sha256": "43f49749fa5a2e755d9641ebaa2ed4a7b69391dd9cf4d53b2c14219d3ca805c3",
+      "source_sha256": "e6dde2008f51d0730e564284455d35bc17d46fcb5572525412d59158b9258224",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-v1.json",
       "target_exists": true,
@@ -482,7 +482,7 @@
       "exists": true,
       "size_bytes": 3956,
       "source": "dist/quality/pattern-inventory-summary-v1.json",
-      "source_sha256": "b413669ecc2ee85e8019bc00c6f7efc321c268b10a8894d55ebea9eec133adfa",
+      "source_sha256": "deea652acad88e70083504df4ace67853f12be886ffa21ac52ad37b3c5a1d110",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-summary-v1.json",
       "target_exists": true,
@@ -493,9 +493,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-queue-report-v1.json",
       "exists": true,
-      "size_bytes": 888530,
+      "size_bytes": 888531,
       "source": "dist/quality/pattern-queue-report-v1.json",
-      "source_sha256": "ec4ef488e92d59d476c2de420c398476d397be2439c1e495b50943b174cac9a8",
+      "source_sha256": "68379a8624e429ac50e4597a76c183f393fdc35aea68e74e857e972404d24994",
       "source_type": "file",
       "target": "dist/quality/pattern-queue-report-v1.json",
       "target_exists": true,

--- a/docs/EXTERNAL-REGO-LIBRARY-REVIEW.md
+++ b/docs/EXTERNAL-REGO-LIBRARY-REVIEW.md
@@ -3,26 +3,36 @@
 This note captures what is worth borrowing from public Kubernetes control
 libraries that organize content as frameworks, controls, and executable rules.
 
-Primary comparison target reviewed in March 2026:
+Primary comparison target refreshed on April 11, 2026:
 - `kubescape/regolibrary`
 
-Observed structure in the March 23, 2026 checkout:
+Observed structure in the April 11, 2026 checkout:
 - 16 frameworks
-- 302 controls
-- 2391 rules
+- 265 controls
+- 274 rule directories
+- 5 attack-track bundles
 - category skew led by Control plane, Workload, Access control, and Network
+- scanning scopes still skew heavily toward cluster and file, with much smaller
+  AKS/EKS/cloud coverage pockets
+
+Current local comparison point in `confighub-patterns`:
+- 25 promoted controls
+- 7 framework views
+- one explicit split between broad canonical patterns and a smaller promoted
+  control/framework surface
 
 Observed product-shape signal:
 - strong breadth in generic control-plane and CIS-style checks
 - meaningful workload, RBAC, secrets, and exposure coverage
-- very little GitOps/operator-specific depth in the public control library
-  surface
+- meaningful provider-managed cluster posture coverage for EKS and AKS
+- very little GitOps/operator-specific depth in the public control-library
+  surface beyond isolated CVE or Argo-centric checks
 
 ## What Is Worth Borrowing
 
 ### 1. Clear promoted taxonomy
 
-The strongest idea is the separation between:
+The strongest idea is the visible separation between:
 - framework views
 - control metadata
 - executable rule logic
@@ -32,7 +42,22 @@ That reinforces the shape we want here:
 - `controls/` as the stable operator-facing promoted subset
 - `frameworks/` as grouped views for standards, platforms, and workflows
 
-### 2. Metadata-rich controls
+### 2. Stable IDs instead of stringly framework membership
+
+One structural detail is worth copying carefully, not literally.
+
+Kubescape makes framework membership and control-library layering very visible,
+but many of its framework references still depend on control names or active
+control lists that are less stable than IDs.
+
+We should keep our current direction:
+- stable `CTRL-*` identifiers for control membership
+- stable `FRM-*` identifiers for framework views
+- explicit projections in `dist/` for released consumers
+
+Borrow the layered shape, not the name-coupling.
+
+### 3. Metadata-rich controls
 
 The useful control-library pattern is not just "a check exists", but:
 - stable IDs
@@ -46,7 +71,7 @@ That maps well to the control-definition shape we already adopted, especially
 for supported surfaces, consumers, evidence expectations, and remediation
 safety.
 
-### 3. Curated baseline frameworks
+### 4. Curated baseline frameworks
 
 The strongest framework idea is not standards-only packaging. The useful part
 is curated operator-facing baseline views like:
@@ -57,7 +82,7 @@ is curated operator-facing baseline views like:
 That is a good fit for our own `frameworks/` layer, especially for a
 cross-family `platform-best` view and future GitOps/operator workflow bundles.
 
-### 4. Frameworks as views, not the source of truth
+### 5. Frameworks as views, not the source of truth
 
 Frameworks are useful when they stay lightweight and opinionated:
 - platform views
@@ -101,7 +126,21 @@ A control library alone does not solve:
 
 We should keep one canonical evidence model across those surfaces.
 
-### 4. Do not chase broad control-plane parity as the near-term goal
+### 4. Do not adopt attack tracks as a top-level taxonomy layer yet
+
+The `attack-tracks/` directory in `regolibrary` is interesting, but it is not a
+good near-term fit for this repo's current contract.
+
+For now, we should prefer:
+- stable patterns
+- promoted controls
+- lightweight frameworks
+- compact operator recipes
+
+If we ever revisit attack-track style packaging, it should come later as a
+derived projection, not as a new source-of-truth layer.
+
+### 5. Do not chase broad control-plane parity as the near-term goal
 
 The external library is rich in:
 - kube-bench-style control-plane flag and file-permission checks
@@ -113,60 +152,52 @@ differentiate first.
 
 ## Concrete Takeaways For This Repo
 
-### Adopt now
+### Keep now
 
 - keep growing `controls/` and `frameworks/` as first-class top-level layers
 - make framework bundles easy to publish in `dist/`
 - keep control metadata rich enough for operator UX and AI explanations
+- keep external-library overlap as mapping data, not copied execution or copied
+  control taxonomies
 
-### Prioritize next
+### What already landed from this review
 
-- GitOps and operator reliability controls
-- RBAC and identity controls
-- network and exposure baseline controls
-- secrets and credential hygiene controls
-- cluster and node hardening controls
-- platform-best framework views that combine the strongest promoted controls
+- `#12` is done: policy-control and admission baseline posture is now visible as
+  promoted controls under `controls/cluster/`
+- `#13` is done: Gateway/public service-edge coverage is now part of the
+  promoted network family
+- `#3` is now a PR-backed bundle-projection contract instead of a vague future
+  cleanup
+- `#15` and `#14` are now PR-backed recipe/schema work instead of loose prose
+  ideas
 
-### Candidate ideas worth importing into our backlog
+### Mapping guidance
 
-- policy-control presence and admission baseline controls
-  - examples: "at least one active policy mechanism", Pod Security Admission
-    posture, safe exception surfaces for hostPath/hostPort/capabilities
-- service-account and secret-access hygiene
-  - default service account usage, token mounting, and broad secret read access
-- service exposure coverage beyond Ingress
-  - gateway-style exposure and controller-specific public surface risks
-- external secret management posture
-  - using external secret stores as a promoted baseline, not just a catalog note
+When an external control library clearly overlaps with our canonical corpus, the
+preferred path is:
+- map external control IDs to canonical `CCVE-*` IDs
+- keep that mapping in `mappings/`
+- avoid importing the external control object as a second source of truth
 
-## March 24 Follow-On Priorities
+Today that already exists for imported Kubescape control IDs in:
+- `mappings/kubescape/kubescape-ccve-mappings-v1.json`
 
-The external Rego review should stay connected to two concrete follow-ons:
+That should remain the model for overlap: explicit mappings, not copied
+taxonomy.
 
-### 1. Keep Kubescape as an intake source for non-GitOps control families
+### Next follow-on from the refreshed review
 
-The strongest near-term Kubescape-style intake areas remain:
-- policy-control and admission baseline controls
-- service-account and secret-access hygiene
-- gateway and public exposure coverage beyond classic Ingress
-- external secret management posture
+The strongest remaining family exposed by the refreshed `regolibrary` checkout
+is provider-managed cluster hardening:
+- private endpoint and private node posture
+- managed-cluster network policy enablement
+- provider-specific identity and registry posture
+- external secret storage and image-scanning expectations
 
-Near-term intake queue to keep explicit while GitOps work continues:
-- admission coverage that answers "is there at least one active policy layer?"
-- service account token-mount and broad secret-read controls
-- gateway and public exposure controls outside classic Ingress-only thinking
-- external secret store posture controls that can become promoted baselines
+That is now captured as:
+- `#18` Review managed-cluster hardening families from external control libraries
 
-Concrete follow-on now landed from that queue:
-- `CTRL-NET-0004` in `controls/network/gateway-api-route-and-tls-baseline.yaml`
-  promotes the first Gateway/public-exposure baseline built from native
-  Gateway API scanner coverage we already have
-
-That is where the public control library has useful breadth we can review for
-candidate promoted controls in `confighub-patterns`.
-
-### 2. Keep GitOps good+bad baselines repo-owned
+### Keep GitOps good+bad baselines repo-owned
 
 For Argo CD and Flux specifically, our primary reference set should remain the
 owned examples in `confighub-scan`:
@@ -174,17 +205,17 @@ owned examples in `confighub-scan`:
 - `examples/gitops-bad-baselines/`
 
 That keeps our GitOps operator story anchored in:
-- repo-vs-live reasoning,
-- Argo/Flux-specific intent and reconcile behavior,
-- promoted controls tied back to our own examples,
+- repo-vs-live reasoning
+- Argo/Flux-specific intent and reconcile behavior
+- promoted controls tied back to our own examples
 - scanner-backed examples that we can use in demos, docs, AI explainers, and
-  future benchmark work.
+  future benchmark work
 
 In other words:
 - use Kubescape/Rego libraries to expand backlog ideas for generic control
-  families,
+  families
 - keep Argo CD and Flux baseline ownership in our own examples and promoted
-  controls.
+  controls
 
 ### Gaps that reinforce our product wedge
 

--- a/mappings/README.md
+++ b/mappings/README.md
@@ -3,7 +3,8 @@
 External mapping tables belong here:
 - Kyverno
 - Trivy
-- future imported-evidence mappings
+- Kubescape imported-evidence overlap mappings
+- future imported-evidence or external control-library overlap mappings
 
 During bootstrap, the active mapping files still live under
 `confighub-scan/risks/`.


### PR DESCRIPTION
## Summary
- refresh the external Rego-library comparison against a current `kubescape/regolibrary` checkout
- make the borrow / reject decisions explicit for `confighub-patterns`
- clarify mapping guidance for external control overlap
- add the next concrete follow-up issue for managed-cluster hardening families
- refresh the first-wave copy manifest so `make validate` stays green against the current sibling `confighub-scan`

## Verification
- `make validate`

Closes #11.
Refs #18.
