### PR TITLE
Record remedies taxonomy decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,6 @@ are in the right repo.
 - `../confighub-scan/README.md`
 - `../confighub-scan/docs/START-HERE.md`
 - `docs/MIGRATION-STATUS.md`
+- `docs/REMEDIES-DECISION.md`
 - `docs/TAXONOMY.md`
 - `dist/bundle-manifest-v1.json`

--- a/dist/first-wave-copy-manifest-v1.json
+++ b/dist/first-wave-copy-manifest-v1.json
@@ -8,10 +8,10 @@
     "schema": 3
   },
   "copy_status_counts": {
-    "copied_drifted": 15,
-    "copied_matching": 24
+    "copied_drifted": 16,
+    "copied_matching": 23
   },
-  "generated_at": "2026-03-31T12:02:45+00:00",
+  "generated_at": "2026-04-11T10:48:42+00:00",
   "item_count": 39,
   "items": [
     {
@@ -165,12 +165,12 @@
     },
     {
       "category": "pattern_quality",
-      "copy_status": "copied_matching",
+      "copy_status": "copied_drifted",
       "destination": "quality/launch-rules-v1.json",
       "exists": true,
-      "size_bytes": 28834,
+      "size_bytes": 29226,
       "source": "risks/quality/launch-rules-v1.json",
-      "source_sha256": "c24ed856f80f507c9d2d5710d56d42e9b6db480e96d208a53b5ac4249d4efcb3",
+      "source_sha256": "21891803f1eb77bfd7fc4c36c8543b8f11cf27ee7e437b21342c47b146b70e66",
       "source_type": "file",
       "target": "quality/launch-rules-v1.json",
       "target_exists": true,
@@ -467,9 +467,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-inventory-v1.json",
       "exists": true,
-      "size_bytes": 4046324,
+      "size_bytes": 4046247,
       "source": "dist/quality/pattern-inventory-v1.json",
-      "source_sha256": "43f49749fa5a2e755d9641ebaa2ed4a7b69391dd9cf4d53b2c14219d3ca805c3",
+      "source_sha256": "e6dde2008f51d0730e564284455d35bc17d46fcb5572525412d59158b9258224",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-v1.json",
       "target_exists": true,
@@ -482,7 +482,7 @@
       "exists": true,
       "size_bytes": 3956,
       "source": "dist/quality/pattern-inventory-summary-v1.json",
-      "source_sha256": "b413669ecc2ee85e8019bc00c6f7efc321c268b10a8894d55ebea9eec133adfa",
+      "source_sha256": "deea652acad88e70083504df4ace67853f12be886ffa21ac52ad37b3c5a1d110",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-summary-v1.json",
       "target_exists": true,
@@ -493,9 +493,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-queue-report-v1.json",
       "exists": true,
-      "size_bytes": 888530,
+      "size_bytes": 888531,
       "source": "dist/quality/pattern-queue-report-v1.json",
-      "source_sha256": "ec4ef488e92d59d476c2de420c398476d397be2439c1e495b50943b174cac9a8",
+      "source_sha256": "68379a8624e429ac50e4597a76c183f393fdc35aea68e74e857e972404d24994",
       "source_type": "file",
       "target": "dist/quality/pattern-queue-report-v1.json",
       "target_exists": true,

--- a/docs/MIGRATION-STATUS.md
+++ b/docs/MIGRATION-STATUS.md
@@ -60,7 +60,7 @@ The target taxonomy is now explicit:
 - `frameworks/` for grouped views over controls
 
 Runtime rule:
-- controls, mappings, remedies, and released bundles belong here
+- controls, mappings, remediation metadata, and released bundles belong here
 - executable detector rules stay in `confighub-scan`
 - ConfigHub functions, standalone cub-based scan, and wrappers all consume the
   same released bundles

--- a/docs/REMEDIES-DECISION.md
+++ b/docs/REMEDIES-DECISION.md
@@ -1,0 +1,124 @@
+# Remedies Decision
+
+Issue `#5` asked whether remedies should become a top-level taxonomy layer in
+`confighub-patterns`.
+
+## Decision
+
+For the current bootstrap and first released-bundle phase:
+
+- keep remedies as metadata attached to patterns and controls
+- do not add a top-level `remedies/` directory yet
+- do not assign stable standalone remedy IDs yet
+
+In other words, `confighub-patterns` should keep owning remediation metadata,
+but not a separate remedy taxonomy.
+
+## Why
+
+### 1. Remedy meaning is still context-heavy
+
+The current model already has two useful layers:
+
+- `patterns/` carry richer remediation detail, optional example commands, and
+  optional function references
+- `controls/` carry compact operator-facing remediation strategy, safety class,
+  and guidance
+
+That works because remediation meaning is often specific to:
+- the exact pattern
+- the operator workflow
+- the supported scan surfaces
+
+Lifting that into a standalone remedy object too early would duplicate meaning
+that still depends on the pattern or control context.
+
+### 2. Reuse is not proven enough yet
+
+Some patterns already reference similarly named fix functions or operational
+moves, but that is not the same as proving we have a stable shared remedy
+catalog.
+
+We should wait for stronger evidence of:
+- many-to-one reuse across unrelated patterns
+- repeated operator guidance that wants one maintained source
+- consumers asking for remedy lookup independent of finding or control lookup
+
+### 3. The current bundle contract already gets the useful parts out
+
+Today we already project the high-value remedy shape into released artifacts:
+- remedy type / strategy
+- safety class
+- human guidance
+- optional function linkage or commands through the pattern/control context
+
+That means current consumers can still answer:
+- what is the safest next move?
+- is this a config fix or a diagnose-then-fix path?
+- should this be automated or reviewed?
+
+without needing a fourth top-level taxonomy.
+
+### 4. A top-level remedy layer would blur repo boundaries too early
+
+If we add `remedies/` now, it becomes tempting to move more executable or
+workflow logic here.
+
+That would be the wrong direction.
+
+The clean split remains:
+- `confighub-patterns`: pattern, control, framework, mapping, and remediation
+  metadata
+- `confighub-scan`: execution, findings model, explain surfaces, and fix-plan
+  orchestration
+
+## Source Of Truth By Layer
+
+### Patterns
+
+Patterns remain the source of truth for:
+- detailed remediation description
+- example commands or fix snippets
+- remedy type and safety classification
+- optional function references when a known helper exists
+
+### Controls
+
+Controls remain the source of truth for:
+- operator-facing remediation strategy
+- safety class at the promoted-control layer
+- short guidance tied to a stable control bundle
+
+### Generated artifacts
+
+Generated bundles and catalogs may continue to normalize or project:
+- remedy class
+- safety class
+- linked function name
+- compact guidance fields
+
+but those projections should stay derived, not become the authoring source.
+
+## What We Are Explicitly Not Doing Yet
+
+- no top-level `remedies/` directory
+- no standalone `RMD-*` or equivalent remedy IDs
+- no separate remedy bundle projection as a first-class release surface
+- no migration of executable fix functions into this repo
+
+## Revisit Triggers
+
+We should revisit this decision only if one or more of these become true:
+
+- the same remedy guidance is reused across many patterns or controls and
+  duplication becomes hard to maintain
+- consumers need remedy lookup independent of pattern or control lookup
+- remedy safety / automation contracts need their own versioned surface
+- we introduce a real release artifact whose primary consumer is remedy-centric
+  rather than finding- or control-centric
+
+Until then, the simplest and safest answer is:
+- keep remedies here as metadata
+- keep execution elsewhere
+- keep the bundle contract focused on patterns, controls, frameworks, mappings,
+  and derived projections

--- a/docs/REPO-SCOPE.md
+++ b/docs/REPO-SCOPE.md
@@ -33,8 +33,8 @@ standalone cub-based scan, and wrapper CLIs.
 ## Repo Boundary
 
 Expected long-term split:
-- `confighub-patterns`: patterns, controls, frameworks, mappings, remedies,
-  schema, quality inputs, runtime bundles
+- `confighub-patterns`: patterns, controls, frameworks, mappings, remediation
+  metadata, schema, quality inputs, runtime bundles
 - `confighub-scan`: engine, adapters, findings model, local bundle consumption,
   engine quality reports
 - ConfigHub/SDK: connected worker execution and orchestration


### PR DESCRIPTION
## Summary
- record the remedies decision for `confighub-patterns`
- keep remedies as pattern/control metadata instead of adding a top-level `remedies/` taxonomy now
- align repo-scope and migration docs with that decision
- refresh the first-wave copy manifest so `make validate` stays green against the current sibling `confighub-scan`

## Decision
- no top-level `remedies/` directory yet
- no standalone remedy IDs yet
- keep detailed remediation on patterns and operator-facing remediation on controls
- revisit only if remedy reuse and consumer needs clearly justify a separate surface

## Verification
- `make validate`

Closes #5.
