### PR TITLE
Seed managed cluster hardening family

### DIFF
--- a/dist/first-wave-copy-manifest-v1.json
+++ b/dist/first-wave-copy-manifest-v1.json
@@ -8,10 +8,10 @@
     "schema": 3
   },
   "copy_status_counts": {
-    "copied_drifted": 15,
-    "copied_matching": 24
+    "copied_drifted": 16,
+    "copied_matching": 23
   },
-  "generated_at": "2026-03-31T12:02:45+00:00",
+  "generated_at": "2026-04-11T10:50:07+00:00",
   "item_count": 39,
   "items": [
     {
@@ -165,12 +165,12 @@
     },
     {
       "category": "pattern_quality",
-      "copy_status": "copied_matching",
+      "copy_status": "copied_drifted",
       "destination": "quality/launch-rules-v1.json",
       "exists": true,
-      "size_bytes": 28834,
+      "size_bytes": 29226,
       "source": "risks/quality/launch-rules-v1.json",
-      "source_sha256": "c24ed856f80f507c9d2d5710d56d42e9b6db480e96d208a53b5ac4249d4efcb3",
+      "source_sha256": "21891803f1eb77bfd7fc4c36c8543b8f11cf27ee7e437b21342c47b146b70e66",
       "source_type": "file",
       "target": "quality/launch-rules-v1.json",
       "target_exists": true,
@@ -467,9 +467,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-inventory-v1.json",
       "exists": true,
-      "size_bytes": 4046324,
+      "size_bytes": 4046247,
       "source": "dist/quality/pattern-inventory-v1.json",
-      "source_sha256": "43f49749fa5a2e755d9641ebaa2ed4a7b69391dd9cf4d53b2c14219d3ca805c3",
+      "source_sha256": "e6dde2008f51d0730e564284455d35bc17d46fcb5572525412d59158b9258224",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-v1.json",
       "target_exists": true,
@@ -482,7 +482,7 @@
       "exists": true,
       "size_bytes": 3956,
       "source": "dist/quality/pattern-inventory-summary-v1.json",
-      "source_sha256": "b413669ecc2ee85e8019bc00c6f7efc321c268b10a8894d55ebea9eec133adfa",
+      "source_sha256": "deea652acad88e70083504df4ace67853f12be886ffa21ac52ad37b3c5a1d110",
       "source_type": "file",
       "target": "dist/quality/pattern-inventory-summary-v1.json",
       "target_exists": true,
@@ -493,9 +493,9 @@
       "copy_status": "copied_drifted",
       "destination": "dist/quality/pattern-queue-report-v1.json",
       "exists": true,
-      "size_bytes": 888530,
+      "size_bytes": 888531,
       "source": "dist/quality/pattern-queue-report-v1.json",
-      "source_sha256": "ec4ef488e92d59d476c2de420c398476d397be2439c1e495b50943b174cac9a8",
+      "source_sha256": "68379a8624e429ac50e4597a76c183f393fdc35aea68e74e857e972404d24994",
       "source_type": "file",
       "target": "dist/quality/pattern-queue-report-v1.json",
       "target_exists": true,

--- a/docs/CANDIDATE-CONTROL-FAMILIES.md
+++ b/docs/CANDIDATE-CONTROL-FAMILIES.md
@@ -118,6 +118,24 @@ Likely early framework views:
 - cluster-hardening
 - platform-best
 
+## 8. Managed Cluster Hardening
+
+Candidate control themes:
+- private endpoint and private node posture
+- managed-cluster network policy enablement
+- provider-native identity and RBAC choices
+- registry and image-scanning posture
+- external secret storage preference in managed environments
+
+Initial framework decision:
+- start with one shared `managed-cluster-hardening` family if this gets
+  promoted
+- do not split by provider until canonical pattern coverage and operator demand
+  clearly justify it
+
+See:
+- `docs/MANAGED-CLUSTER-HARDENING-SEED.md`
+
 ## Promotion Rule
 
 Use controls when we want a stable, operator-facing check.

--- a/docs/MANAGED-CLUSTER-HARDENING-SEED.md
+++ b/docs/MANAGED-CLUSTER-HARDENING-SEED.md
@@ -1,0 +1,154 @@
+# Managed Cluster Hardening Seed
+
+This note narrows the managed-cluster follow-up from the external Rego-library
+review into a small, repo-scoped candidate family for `confighub-patterns`.
+
+It is intentionally a shortlist, not a promise to copy provider libraries
+wholesale.
+
+## Why This Family Is Worth Separating
+
+The refreshed `kubescape/regolibrary` review showed one external area with real
+breadth that we do not yet expose clearly here:
+- private endpoint / private node posture
+- managed-cluster network policy enablement
+- provider-native identity and RBAC posture
+- registry and image-scanning expectations
+- external secret storage posture in managed environments
+
+That does not mean we should copy provider-specific control libraries as-is.
+It does mean we now have enough signal to treat managed-cluster hardening as a
+distinct candidate family rather than burying it inside generic cluster
+hardening.
+
+## Proposed Family Shape
+
+Start with one family:
+- `managed-cluster-hardening`
+
+Do not split into separate provider frameworks yet.
+
+Reason:
+- the first useful questions are cross-provider
+- our current promoted taxonomy is still intentionally compact
+- provider-specific frameworks would be harder to maintain before canonical
+  pattern coverage is deeper
+
+Revisit per-provider splits only if:
+- EKS / AKS / GKE coverage diverges materially
+- consumers need provider-specific bundle views
+- we accumulate enough promoted controls that one shared framework becomes noisy
+
+## First Candidate Control Themes
+
+### 1. Control-plane endpoint exposure baseline
+
+Candidate themes:
+- private endpoint enabled
+- public endpoint disabled or tightly bounded
+- control-plane access intentionally narrowed
+
+Why it matters:
+- this is one of the clearest provider-managed posture defaults that operators
+  routinely ask about
+- it translates cleanly into an operator-facing "good baseline" control story
+
+### 2. Private-node and workload-isolation baseline
+
+Candidate themes:
+- private nodes where the platform supports them
+- restricted workload placement for untrusted or multi-tenant workloads
+- container-optimized node posture when relevant
+
+Why it matters:
+- it is a durable operator choice, not just a one-off CVE workaround
+
+### 3. Managed-cluster network policy baseline
+
+Candidate themes:
+- network policy engine enabled
+- namespaces expected to be isolated actually have policy coverage
+- provider-specific defaults do not silently leave east-west traffic open
+
+Why it matters:
+- this is where generic network controls and managed-cluster posture meet
+- it belongs in a managed-cluster family only when the platform toggle or
+  default matters
+
+### 4. Provider-native identity boundary baseline
+
+Candidate themes:
+- dedicated service-account identity patterns
+- provider-native RBAC or auth integration choices
+- avoid over-broad registry or cluster access in managed IAM wiring
+
+Why it matters:
+- this is broader than generic RBAC and often needs provider-aware language
+
+### 5. Registry and image-scanning posture
+
+Candidate themes:
+- provider registry access minimization
+- image vulnerability scanning enabled through the native platform or an
+  equivalent external provider
+
+Why it matters:
+- operators usually want a policy answer here, not just a catalog footnote
+
+### 6. External secret storage preference
+
+Candidate themes:
+- prefer external secret storage over static in-cluster secret handling when the
+  platform and operating model support it
+- treat cloud secret-store posture as part of the managed-cluster baseline
+
+Why it matters:
+- this connects existing secrets guidance to real managed-environment defaults
+
+## What Should Stay Out For Now
+
+Do not treat the managed-cluster family as:
+- a copy of EKS / AKS / GKE provider docs
+- a second CIS-style control-plane checklist
+- a place to mirror every external control-library ID
+
+This family should stay small and promote only the controls that:
+- map cleanly to canonical patterns
+- have clear operator value
+- fit our released bundle model
+
+## Relationship To Existing Families
+
+Keep these boundaries clear:
+
+- generic Kubernetes API-server, kubelet, and certificate posture stays under
+  `cluster-hardening`
+- generic RBAC and service-account posture stays under `rbac-and-identity`
+- generic secret handling stays under `secrets-and-credentials`
+- generic Ingress / Gateway / exposure posture stays under `network-exposure`
+
+Use the managed-cluster family only when provider-managed defaults or cloud
+platform posture are the actual source of the control value.
+
+## Framework Decision
+
+If this family gets promoted, start with one framework candidate:
+- `managed-cluster-hardening`
+
+Do not start with:
+- one framework per cloud
+- one framework per registry
+- one framework per identity provider
+
+That can come later if the promoted control set becomes too wide.
+
+## Promotion Rule For This Family
+
+Promote controls here only when at least one of these is true:
+- the pattern corpus already contains a clean canonical match
+- the operator value is clearly cross-provider even if examples are provider-specific
+- the control can be explained without importing an external execution model
+
+If the underlying pattern or evidence surface is still missing, leave it as:
+- a candidate here
+- a follow-on for pattern growth in `confighub-scan`


### PR DESCRIPTION
## Summary
- add a small managed-cluster hardening seed note
- extend the candidate-family doc with the new managed-cluster family
- make the first framework decision explicit: one shared family first, provider splits later only if justified
- refresh the first-wave copy manifest so `make validate` stays green against the current sibling `confighub-scan`

## Outputs
- `docs/MANAGED-CLUSTER-HARDENING-SEED.md`
- updated `docs/CANDIDATE-CONTROL-FAMILIES.md`

## Verification
- `make validate`

Closes #18.
